### PR TITLE
Remove redundant comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,6 @@
 
 module.exports = function(obj, opt){
     if(arguments.length > 1)
-        return obj !== undefined && obj != null ? obj : opt;
-    return obj !== undefined && obj != null;
+        return obj != null ? obj : opt;
+    return obj != null;
 };


### PR DESCRIPTION
You don't need both `obj !== undefined` and `obj != null` comparisons, since [undefined == null](http://es5.github.io/#x11.9.3) anyway (and it is the only thing that `== null` except `null` itself).
